### PR TITLE
Updated snipcart version.

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -15,8 +15,8 @@ exports.onRenderBody = function (_ref) {
 	options = Object.assign({
 		apiKey: process.env.GATSBY_SNIPCART_API_KEY,
 		autopop: false,
-		js: 'https://cdn.snipcart.com/themes/v3.0.6/default/snipcart.js',		
-		styles: 'https://cdn.snipcart.com/themes/v3.0.6/default/snipcart.css',
+		js: 'https://cdn.snipcart.com/themes/v3.0.15/default/snipcart.js',		
+		styles: 'https://cdn.snipcart.com/themes/v3.0.15/default/snipcart.css',
 	}, options);
 
 	if (!options.apiKey) {


### PR DESCRIPTION
When I use this plugin, the gatsby-ssr from root is used. I updated the snipcart in this file aswell...
Whan I validate the code I see in /src/gatsby-ssr, there's a bracket '}' too much after const components, I think that's also a bug, or not?