### PR TITLE
default to snipcart v3.0.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # gatsby-plugin-snipcartv3
 
-Now On SnipCart v3.0.22 🚀
+Now On SnipCart v3.0.27 🚀
 
 An update to the wildly popular & original `gatsby-plugin-snipcart`.
 
-A plugin for using the latest Version v3.0.22 of [Snipcart](https://snipcart.com/) with [Gatsby](https://www.gatsbyjs.org/).
+A plugin for using the latest Version v3.0.27 of [Snipcart](https://snipcart.com/) with [Gatsby](https://www.gatsbyjs.org/).
 
 ## Install
 
@@ -51,6 +51,6 @@ To add a snipcart product to yor site, just add a HTML element with the data typ
 
 `autopop`: Whether or not the cart will open once a product is added. (Defaults to `false`)
 
-`js`: A Snipcart JavaScript file. (Defaults to `https://cdn.snipcart.com/themes/v3.0.22/default/snipcart.js`)
+`js`: A Snipcart JavaScript file. (Defaults to `https://cdn.snipcart.com/themes/v3.0.27/default/snipcart.js`)
 
-`styles`: A stylesheet file to link to. Set to `false` for none. (Defaults to `https://cdn.snipcart.com/themes/v3.0.22/default/snipcart.css`)
+`styles`: A stylesheet file to link to. Set to `false` for none. (Defaults to `https://cdn.snipcart.com/themes/v3.0.27/default/snipcart.css`)

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -15,8 +15,8 @@ exports.onRenderBody = function (_ref) {
 	options = Object.assign({
 		apiKey: process.env.GATSBY_SNIPCART_API_KEY,
 		autopop: false,
-		js: 'https://cdn.snipcart.com/themes/v3.0.22/default/snipcart.js',		
-		styles: 'https://cdn.snipcart.com/themes/v3.0.22/default/snipcart.css',
+		js: 'https://cdn.snipcart.com/themes/v3.0.27/default/snipcart.js',
+		styles: 'https://cdn.snipcart.com/themes/v3.0.27/default/snipcart.css',
 	}, options);
 
 	if (!options.apiKey) {


### PR DESCRIPTION
There were some bug fixes from the snipcart team around checkboxes in the shopping cart. The bug was: the id in the label element was not necessarily unique in the cart, so when you checked the checkbox for one item, it would check it for all items in the cart as well.

The fix is there in v3.0.27.